### PR TITLE
move snyk to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "lodash.isfunction": "^3.0.9",
     "lodash.isobjectlike": "^4.0.0",
     "mobx": "^6.0.1",
-    "mobx-react": "^7.0.0",
-    "snyk": "^1.192.3"
+    "mobx-react": "^7.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.x.x",
@@ -60,6 +59,7 @@
     "react-test-renderer": "^16.9.0",
     "semver": "5.x.x",
     "shell-utils": "1.x.x",
+    "snyk": "^1.192.3",
     "xo": "0.18.x"
   },
   "peerDependencies": {


### PR DESCRIPTION
#pr
among other unused libs, it brings in `'@'sentry/node`
```
│ └─┬ snyk'@'1.1182.0
│ └─┬ '@'sentry/node'@'7.55.2
│ ├─┬ '@'sentry-internal/tracing'@'7.55.2
│ │ └── '@'sentry/core'@'7.55.2
│ └── '@'sentry/core'@'7.55.2
```